### PR TITLE
adding container tools to reproducibility page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-Welcome to the **open science knowledge base**! This is an annotated collection of practical resources for researchers interested in using open practices in their work. [Additions and revisions](community/contribute.md) are very welcome!
+Welcome to the **open science knowledge base**! This is an annotated collection of practical resources for researchers interested in using open practices in their work. [Additions and revisions](content/change/community/contribute.md) are very welcome!
 

--- a/content/analyze/reproducibility.md
+++ b/content/analyze/reproducibility.md
@@ -13,6 +13,8 @@ The list of demands and best practices can seem overwhelming at times, but as Kl
 
 **For maximum reproducibility, freely available tools that can be picked up by any colleague are often more helpful than proprietary, commercial tools.** Thankfully, there are several sets of tools to choose from:
 
+### Scientific Programming 
+
 * The [`R`](https://cran.rstudio.com/) programming language and the corresponding [RStudio](https://www.rstudio.com/) interface.
 * [Python](https://www.python.org/) and [Jupyter](https://jupyter.org/) provide an alternative approach.
 * [Julia](https://julialang.org/) is a programming language focussed on high-performance numerical computation.
@@ -25,6 +27,15 @@ The list of demands and best practices can seem overwhelming at times, but as Kl
     * The Software Carpentry offers an [**introduction to `R`** for non-programmers](http://swcarpentry.github.io/r-novice-gapminder/).
     * RStudio's [`R` **Cheatsheets**](https://www.rstudio.com/resources/cheatsheets/) are a fantastic resource for finding `R` commands for any particular purpose.
     * [`R` for Data Science](http://r4ds.had.co.nz/) by Grolemund & Wickham is a more comprehensive, and also more advanced, tutorial that covers all aspects of data analysis.
+
+### Containers
+
+* [Singularity](https://singularityware.github.io/) containers offer a secure means to distribute scientific applications on a shared resource.
+* [Docker`](https://docs.docker.com/get-started/) is ideal for building a container intended for local use, or for conversion to Singularity, allowing for both use cases easily.
+* [The Experiment Factory](https://expfactory.github.io/) to generate reproducible container based behavioral experiments.
+* [The Scientific Filesystem](https://sci-f.github.io/) and it's associated [Container Builder](https://sci-f.github.io/) to easily plug your code into a `build` --> `test` --> `deploy` framework.
+* [Container Tools](https://singularityhub.github.io/) for a wide range of open source tools for containers optimized for open science.
+
 
 ----
 

--- a/content/analyze/reproducibility.md
+++ b/content/analyze/reproducibility.md
@@ -30,6 +30,8 @@ The list of demands and best practices can seem overwhelming at times, but as Kl
 
 ### Containers
 
+> Containers help to ensure that your analysis runs today, and in years to come.
+
 * [Singularity](https://singularityware.github.io/) containers offer a secure means to distribute scientific applications on a shared resource.
 * [Docker`](https://docs.docker.com/get-started/) is ideal for building a container intended for local use, or for conversion to Singularity, allowing for both use cases easily.
 * [The Experiment Factory](https://expfactory.github.io/) to generate reproducible container based behavioral experiments.

--- a/content/analyze/reproducibility.md
+++ b/content/analyze/reproducibility.md
@@ -39,6 +39,14 @@ The list of demands and best practices can seem overwhelming at times, but as Kl
 * [Container Tools](https://singularityhub.github.io/) for a wide range of open source tools for containers optimized for open science.
 
 
+!!! tip "Container Resources"
+    If you are new to using containers, there are several fantastic resources to help you get started:
+
+    * The preprint [Computational Reproducibility via Containers in Social Psychology](https://psyarxiv.com/mf82t/), is a solid introduction and overview to container technology, and its importance for reproducibility.
+    * [Singularity: Scientific containers for mobility of compute](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0177459) and [Enhancing reproducibility in scientific computing: Metrics and registry for Singularity containers](http://journals.plos.org/plosone/article?id=10.1371/journal.pone.0188511) discusses challenges specific to container technologies on shared resources that are common to academic institutions.
+    * [The Scientific Filesystem](https://academic.oup.com/gigascience/article/7/5/giy023/4931737) reviews some of the challenges and offers a solution for creating modular, discoverable container software.
+
+
 ----
 
 ## Open and documented data formats

--- a/content/change/community/contribute.md
+++ b/content/change/community/contribute.md
@@ -33,3 +33,65 @@ If you have an idea for a new entry, please reach out to [Felix Henninger](http:
 
 
     -A friendly and smart contributor
+
+
+## How can I develop content locally?
+These instructions are intended for those users on Linux or Unix flavored systems
+with a command line. If you are using Windows, the easier option might be to
+[open an issue](https://github.com/FelixHenninger/open-science-knowledge-base/issues) or use the contact above to request a change.
+
+
+### 1. Fork and Clone the Repository on Github
+If you want to dig in and contribute directly, you can clone the repository,
+check out a new branch, and then develop locally. FIrst, you should fork the
+repository to your Github account. If your username is `waffles` after you
+fork, you would clone like this:
+
+```bash
+$ git clone https://www.github.com/waffles/open-science-knowledge-base
+$ cd open-science-knowledge-base
+```
+
+### 2. Create a New Branch
+
+At this point, you are on the `master` branch, which is the main branch of the
+repository that should be kept in line with the upstream (the primary repository).
+In order to cleanly separate your changes, you should first checkout a new branch:
+
+```bash
+$ git checkout -b add/my-addition master
+```
+
+### 3. Make Changes
+Then, make changes to your heart's content! The project uses [mkdocs](https://www.mkdocs.org)
+so you should first install it:
+
+```bash
+$ pip install mkdocs
+```
+
+The theme that we use is [Material](https://squidfunk.github.io/mkdocs-material/) so
+you need to install that too.
+
+```bash
+$ pip install mkdocs-material
+```
+
+and then start a local server to see your changes in action!
+
+```bash
+$ mkdocs serve
+INFO    -  Building documentation... 
+INFO    -  Cleaning site directory 
+[I 180628 10:57:20 server:292] Serving on http://127.0.0.1:8000
+[I 180628 10:57:20 handlers:59] Start watching changes
+[I 180628 10:57:20 handlers:61] Start detecting changes
+```
+
+And open up [http://127.0.0.1:8000](http://127.0.0.1:8000) to see the site. As you
+edit the local text files, you will see the server rebuild automatically!
+If you need more detail or instruction, please see the link provided above.
+
+### 4. Create a Pull Request
+
+When you are ready you can opena [pull request](https://help.github.com/articles/about-pull-requests/) to the primary repository master branch, and discuss your changes with the maintainers. Please be sure to include details about your contribution.


### PR DESCRIPTION
This PR will close #6 by fixing the link to the contribute.md page, and do the following:

### Reproducibility Sections
I've added categories (subsections) to the list of open source tools, because there are **many** resources that should be discovered here, and they are likely to be best organized in these subsections. Currently, my changes add "Scientific Programming" to describe python, R, etc., and then "Containers" to describe a subset of reproducible container technologies. E.g.:

![image](https://user-images.githubusercontent.com/814322/42052760-8ec70530-7ac4-11e8-8480-2fb326b33352.png)

Another thing I am thinking about - there isn't any AUTHORS.md file or similar - how do you want contributors to the repo to add their contribution history?  As always @FelixHenninger, this site is totally beautiful and I am just going to leave the server main page open on my computer to stare at the colors ;)