### PR TITLE
Remove "prereg challenge"

### DIFF
--- a/content/plan/preregistration/how.md
+++ b/content/plan/preregistration/how.md
@@ -13,7 +13,7 @@ The Open Science Framework has collected [pre-made documents for each of these t
 * **AsPredicted** boils the preregistration down to [eight questions](https://aspredicted.org/nfj4s.pdf), and is probably the shortest and most straight-forward format available.
 * **Brandt et al. \(2013\)** provide a [recipe specifically for preregistering replications](https://osf.io/4jd46/)
 * **van 't Veer and Gina-Sorolla** \(2016\) suggest a [template geared toward experimental research](https://osf.io/56g8e/), and helpfully distinguish between essential and optional, but recommended, elements.
-* The **Preregistration Challenge** provides arguably the most [comprehensive template](https://osf.io/jea94/).
+* The **OSF Prereg** provides arguably the most [comprehensive template](https://osf.io/jea94/).
 * For **(re)analyses of existing data**, there's a [secondary data preregistration template](https://osf.io/djgvw/) by Sara J. Weston and Marjan Bakker
 
 ## Archive


### PR DESCRIPTION
After the Prereg Challenge ended, we revised that template and renamed it to "OSF Prereg" Link is still correct though